### PR TITLE
Modified readme to fit laravel 5.5 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ or add the following to your `composer.json` file :
 "roumen/sitemap": "2.7.*"
 ```
 
-Then register this service provider with Laravel :
+If you are using laravel 5.5 or higher you can skip the service provider registration!
+
+If you are using laravel 5.4 or lower register this service provider with Laravel :
 
 ```php
 'Roumen\Sitemap\SitemapServiceProvider',


### PR DESCRIPTION
I've modified the readme file to fit laravel 5.5.

In laravel 5.5 - thanks to the package auto-discovery - you don't need to register the service provider manually. I have seen that you are using the package auto discovery in your composer.json file.

Have a nice day,
Jordan